### PR TITLE
Allow to be able to install in any rails 7x

### DIFF
--- a/trix.gemspec
+++ b/trix.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rails', ['> 4.1', '< 7.1']
+  spec.add_runtime_dependency 'rails', ['> 4.1', '< 8.0']
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler', '~> 1.10'


### PR DESCRIPTION
Same as: https://github.com/bullet-train-co/trix/pull/1
But to we be able to install in any rails 7x (including a possible 7.2 version)